### PR TITLE
use symplify/autowire-array-parameter: ^11.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/console": "^6.2",
         "symfony/dependency-injection": "6.1.*",
         "symfony/http-kernel": "6.1.*",
-        "symplify/autowire-array-parameter": "^11.1.25",
+        "symplify/autowire-array-parameter": "^11.2",
         "symplify/package-builder": "^11.2",
         "symplify/smart-file-system": "^11.2",
         "webmozart/assert": "^1.11"


### PR DESCRIPTION
Ref error 

```
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - symplify/symplify-kernel dev-main requires symplify/autowire-array-parameter ^11.1.25 -> satisfiable by symplify/autowire-array-parameter[dev-main, 11.1.25, 11.2.x-dev (alias of dev-main)] from composer repo (https://repo.packagist.org/) but symplify/autowire-array-parameter is the root package and cannot be modified. See https://getcomposer.org/dep-on-root for details and assistance.
    - symplify/symplify-kernel 11.2.x-dev is an alias of symplify/symplify-kernel dev-main and thus requires it to be installed too.
    - Root composer.json requires symplify/symplify-kernel ^11.2 -> satisfiable by symplify/symplify-kernel[11.2.x-dev (alias of dev-main)].
    - 
 ```
   
See https://github.com/symplify/autowire-array-parameter/actions/runs/4082329734/jobs/7036566141