### PR TITLE
fix: Always prepend default config files

### DIFF
--- a/src/HttpKernel/AbstractSymplifyKernel.php
+++ b/src/HttpKernel/AbstractSymplifyKernel.php
@@ -33,7 +33,13 @@ abstract class AbstractSymplifyKernel implements LightKernelInterface
 
         $compilerPasses[] = new AutowireArrayParameterCompilerPass();
 
-        $configFiles[] = SymplifyKernelConfig::FILE_PATH;
+        // Always prepend default config files
+        $configFiles = array_merge(
+            [
+                SymplifyKernelConfig::FILE_PATH,
+            ],
+            $configFiles,
+        );
 
         $containerBuilder = $containerBuilderFactory->create($configFiles, $compilerPasses, $extensions);
         $containerBuilder->compile();


### PR DESCRIPTION
Fixes symplify/monorepo-builder#24 and must be merged along with symplify/monorepo-builder!32

- https://github.com/symplify/monorepo-builder/issues/24
- https://github.com/symplify/monorepo-builder/pull/32

